### PR TITLE
Fix: Replace HTML img tags with Markdown for static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-<img src="./static/img/logo.svg" height="72px"/>
+![Logo](./static/img/logo.svg)
 
 </div>
 <br>

--- a/docs/ReadMe.md
+++ b/docs/ReadMe.md
@@ -1,7 +1,7 @@
 <br />
 
 <div align="center">
-<img src="./static/img/logo.svg" height="72px"/>
+![Logo](./static/img/logo.svg)
 </div>
 
 **کنار دیوار** بستری برای افزودن اطلاعات و خدمات به دیوار است.
@@ -241,7 +241,7 @@
 
 <div align="center">
 
-<img src="./static/img/wire-puzzle.svg" height="156px"/>
+![Wire Puzzle](./static/img/wire-puzzle.svg)
 
 </div>
 

--- a/docs/chat/ReadMe.md
+++ b/docs/chat/ReadMe.md
@@ -58,7 +58,7 @@
 
 <div align="center">
 
-<img src="../static/img/wire-puzzle.svg" height="156px"/>
+![Wire Puzzle](../static/img/wire-puzzle.svg)
 
 </div>
 

--- a/docs/chat/users_conversations.md
+++ b/docs/chat/users_conversations.md
@@ -185,7 +185,7 @@ HTTP/1.1  412
 
 <div align="center">
 
-<img src="../static/img/wire-puzzle.svg" height="156px"/>
+![Wire Puzzle](../static/img/wire-puzzle.svg)
 
 </div>
 

--- a/docs/management/ReadMe.md
+++ b/docs/management/ReadMe.md
@@ -219,7 +219,7 @@ API-Version: 2
 
 <div align="center">
 
-<img src="../static/img/wire-puzzle.svg" height="156px"/>
+![Wire Puzzle](../static/img/wire-puzzle.svg)
 
 </div>
 

--- a/docs/management/api-keys.md
+++ b/docs/management/api-keys.md
@@ -125,7 +125,7 @@ x-api-key: {{apikey}}
 
 <div align="center">
 
-<img src="../static/img/wire-puzzle.svg" height="156px"/>
+![Wire Puzzle](../static/img/wire-puzzle.svg)
 
 </div>
 

--- a/docs/oauth/ReadMe.md
+++ b/docs/oauth/ReadMe.md
@@ -305,7 +305,7 @@ Content-Type: application/x-www-form-urlencoded
 
 <div align="center">
 
-<img src="../static/img/wire-puzzle.svg" height="156px"/>
+![Wire Puzzle](../static/img/wire-puzzle.svg)
 
 </div>
 

--- a/docs/standards/policies.md
+++ b/docs/standards/policies.md
@@ -172,7 +172,7 @@
 
 <div align="center">
 
-<img src="../static/img/wire-puzzle.svg" height="156px"/>
+![Wire Puzzle](../static/img/wire-puzzle.svg)
 
 </div>
 


### PR DESCRIPTION
This PR fixes 404 errors for the logo and wire puzzle images by changing HTML `<img>` tags to Markdown syntax.

Docusaurus requires Markdown for static asset processing, as noted in their documentation: [docusaurus.io/docs/static-assets](https://docusaurus.io/docs/static-assets)

> ### Use Markdown syntax
> Docusaurus will only parse links that are in Markdown syntax. If your asset references are using the JSX tag <a> / <img>, nothing will be done.

This change affects image display sizes:
*   **Logo:** Was `72px` (HTML height), now `64px` (SVG default).
*   **Wire Puzzle:** Was `156px` (HTML height), now `201.5px` (SVG default).

The current sizes are based on the SVG's inherent dimensions. While we could modify the SVG files themselves to scale them to match the previous pixel dimensions, these changes don't appear to be major visual disruptions.

Fixes #165 