### PR TITLE
Fix: Apply Vazirmatn font to headings

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -74,3 +74,7 @@
 body {
   font-family: Vazirmatn, sans-serif;
 }
+
+:root {
+  --ifm-heading-font-family: Vazirmatn, sans-serif;
+}


### PR DESCRIPTION
This PR updates the CSS to ensure that headings correctly use the `Vazirmatn` font family. This is done by setting the `--ifm-heading-font-family` CSS variable in `custom.css`.


![Screenshot From 2025-05-16 22-06-06](https://github.com/user-attachments/assets/51c8b4e5-32ac-49e9-87a3-e8f63ced9271)
![Screenshot From 2025-05-16 22-05-46](https://github.com/user-attachments/assets/d970ad3f-2885-424c-8356-8c3e40a53bd7)
