### PR TITLE
fix key in a widget example

### DIFF
--- a/docs/widgets/ReadMe.md
+++ b/docs/widgets/ReadMe.md
@@ -11,8 +11,7 @@
     {
       "description_row": {
         "text": "این یک دسکریپشن رو هست",
-        "has_divider": false,
-        "expandable": false
+        "has_divider": false
       },
       "semantic_paths": {
         "a sample sentence": "text"


### PR DESCRIPTION
`expandable` is not a key in subtitle_row based on the docs in [here](https://divar-ir.github.io/kenar-docs/widgets/subtitle_row)