### PR TITLE
Remove Content-Length header from image upload example

### DIFF
--- a/docs/widgets/image.md
+++ b/docs/widgets/image.md
@@ -23,7 +23,6 @@ sequenceDiagram
 PUT /v2/image-service/open-platform/image.jpg HTTP/1.1
 Host: divar.ir
 Content-Type: image/jpeg
-Content-Length: 22
 
 "<file contents here>"
 ```


### PR DESCRIPTION
The provided Content-Length header is misleading as it is often automatically calculated by the client